### PR TITLE
Cargo audit job changes to `rustsec/audit-check@v2` as `cargo-audit` …

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,8 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Audit
-        run: cargo audit
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     name: Test Suite

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,8 @@ jobs:
 
   audit:
     runs-on: ubuntu-latest
+    env:
+      RUST_LOG: '' # Otherwise audit-check errors on attempting to parse the logging output
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fix
+
+- CI: Cargo audit job changes to `rustsec/audit-check@v2` as `cargo-audit` is no longer installed on GitHub VMs by default
+
 ### Dependencies
 
 - `serde`: 1.0.215 → 1.0.217


### PR DESCRIPTION
…is no longer installed on GitHub VMs by default
