### PR TITLE
allow deleting invidual loaded files & show which plots comes from which logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Allow deleting individual loaded files without removing everything at once
+
+
 ## [1.3.8]
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [1.4.0]
+
 ### Added
 
 - Allow deleting individual loaded files without removing everything at once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Allow deleting individual loaded files without removing everything at once
-
+- Allow deleting individual loaded files without removing everything at once.
+- Hovering the cursor over a loaded log will highlight the plots and plot labels that came from that log.
 
 ## [1.3.8]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator3000"
-version = "1.3.8"
+version = "1.4.0"
 dependencies = [
  "axoupdater",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "plotinator3000"
 description = "Log viewer app for viewing plots of data from projects such as motor and generator control"
 authors = ["SkyTEM Surveys", "Marc Beck König"]
-version = "1.3.8"
+version = "1.4.0"
 edition = "2021"
 repository = "https://github.com/luftkode/plotinator3000"
 homepage = "https://github.com/luftkode/plotinator3000"

--- a/crates/plot_util/src/lib.rs
+++ b/crates/plot_util/src/lib.rs
@@ -91,6 +91,7 @@ fn plot_with_mipmapping(
                 (plot_points_min, plot_points_max),
                 line_width,
                 plot_vals.get_color(),
+                plot_vals.get_highlight(),
             );
         }
     }
@@ -134,14 +135,21 @@ fn plot_min_max_lines(
     (points_min, points_max): (Vec<[f64; 2]>, Vec<[f64; 2]>),
     line_width: f32,
     color: Color32,
+    highlight: bool,
 ) {
     let mut label_min = base_label.to_owned();
     label_min.push_str(" (min)");
     let mut label_max = base_label.to_owned();
     label_max.push_str(" (max)");
 
-    let line_min = Line::new(points_min).name(label_min).color(color);
-    let line_max = Line::new(points_max).name(label_max).color(color);
+    let line_min = Line::new(points_min)
+        .name(label_min)
+        .color(color)
+        .highlight(highlight);
+    let line_max = Line::new(points_max)
+        .name(label_max)
+        .color(color)
+        .highlight(highlight);
 
     plot_ui.line(line_min.width(line_width));
     plot_ui.line(line_max.width(line_width));
@@ -155,7 +163,10 @@ pub fn plot_labels(plot_ui: &mut egui_plot::PlotUi, plot_data: &PlotData, id_fil
     {
         for label in plot_labels.labels() {
             let point = PlotPoint::new(label.point()[0], label.point()[1]);
-            let txt = egui::RichText::new(label.text()).size(10.0);
+            let mut txt = egui::RichText::new(label.text()).size(10.0);
+            if plot_labels.get_highlight() {
+                txt = txt.strong();
+            }
             let txt = egui_plot::Text::new(point, txt);
             plot_ui.text(txt);
         }
@@ -167,7 +178,8 @@ fn plot_raw(plot_ui: &mut egui_plot::PlotUi, plot_vals: &PlotValues, x_min_max_e
     let filtered_points = filter_plot_points(plot_points, x_min_max_ext);
     let line = Line::new(filtered_points)
         .name(plot_vals.label())
-        .color(plot_vals.get_color());
+        .color(plot_vals.get_color())
+        .highlight(plot_vals.get_highlight());
     plot_ui.line(line);
 }
 

--- a/crates/plot_util/src/plots/plot_data.rs
+++ b/crates/plot_util/src/plots/plot_data.rs
@@ -81,6 +81,7 @@ pub struct PlotValues {
     // Label = "<name> #<log_id>"
     label: String,
     color: Color32,
+    highlight: bool,
 }
 
 type PointList<'pl> = &'pl [[f64; 2]];
@@ -108,6 +109,7 @@ impl PlotValues {
             label,
             // Color32::TRANSPARENT means we auto assign one
             color: Color32::TRANSPARENT,
+            highlight: false,
         }
     }
 
@@ -198,6 +200,16 @@ impl PlotValues {
     pub fn label(&self) -> &str {
         &self.label
     }
+
+    /// Whether or not the line should be highlighted
+    pub fn get_highlight(&self) -> bool {
+        self.highlight
+    }
+
+    /// Mutable reference to whether or not the line should be highlighted
+    pub fn get_highlight_mut(&mut self) -> &mut bool {
+        &mut self.highlight
+    }
 }
 
 /// Represents all the plotlabels from a given log
@@ -205,6 +217,7 @@ impl PlotValues {
 pub struct StoredPlotLabels {
     pub log_id: usize,
     pub label_points: Vec<PlotLabel>,
+    pub highlight: bool,
 }
 
 impl StoredPlotLabels {
@@ -212,6 +225,7 @@ impl StoredPlotLabels {
         Self {
             label_points: label_points.into_iter().map(PlotLabel::from).collect(),
             log_id,
+            highlight: false,
         }
     }
 
@@ -231,6 +245,16 @@ impl StoredPlotLabels {
 
     pub fn log_id(&self) -> usize {
         self.log_id
+    }
+
+    /// Whether or not the labels should be highlighted
+    pub fn get_highlight(&self) -> bool {
+        self.highlight
+    }
+
+    /// Mutable reference to whether or not the labels should be highlighted
+    pub fn get_highlight_mut(&mut self) -> &mut bool {
+        &mut self.highlight
     }
 }
 

--- a/src/plot/plot_settings.rs
+++ b/src/plot/plot_settings.rs
@@ -55,6 +55,7 @@ pub struct PlotSettings {
     ps_ui: PlotSettingsUi,
     log_start_date_settings: Vec<LoadedLogSettings>,
     mipmap_settings: MipMapSettings,
+    apply_deletions: bool,
 }
 
 impl PlotSettings {
@@ -142,6 +143,26 @@ impl PlotSettings {
                             );
                         });
                         egui::Grid::new("log_settings_grid").show(ui, |ui| {
+                            ui.label("");
+                            ui.label("");
+                            ui.label("");
+                            let any_marked_for_deletion = self
+                                .log_start_date_settings
+                                .iter()
+                                .any(|s| s.marked_for_deletion());
+                            let apply_text = if any_marked_for_deletion {
+                                RichText::new("Apply").strong()
+                            } else {
+                                RichText::new("Apply")
+                            };
+                            if ui
+                                .add_enabled(any_marked_for_deletion, egui::Button::new(apply_text))
+                                .clicked()
+                            {
+                                self.apply_deletions = true;
+                            }
+
+                            ui.end_row();
                             for settings in &mut self.log_start_date_settings {
                                 loaded_logs::log_date_settings_ui(ui, settings);
                                 ui.end_row();
@@ -155,6 +176,10 @@ impl PlotSettings {
     /// Needs to be called once (and only once!) per frame before querying for plot ui settings, such as
     /// how many plots to paint and more.
     pub fn refresh(&mut self, plots: &mut Plots) {
+        if self.apply_deletions {
+            self.remove_if_marked_for_deletion(plots);
+            self.apply_deletions = false;
+        }
         self.update_plot_dates(plots);
         self.calc_plot_display_settings(plots);
         // If true then we set it to false such that it is only true for one frame
@@ -256,6 +281,47 @@ impl PlotSettings {
         for settings in &mut self.log_start_date_settings {
             date_settings::update_plot_dates(&mut self.invalidate_plot, plots, settings);
         }
+    }
+
+    // Remove log settings and plots that match their ID if they are marked for deletion
+    fn remove_if_marked_for_deletion(&mut self, plots: &mut Plots) {
+        // Get the log IDs for settings marked for deletion
+        let log_ids_to_remove: Vec<usize> = self
+            .log_start_date_settings
+            .iter()
+            .filter(|settings| settings.marked_for_deletion())
+            .map(|settings| settings.log_id())
+            .collect();
+
+        // Return early if nothing to remove
+        if log_ids_to_remove.is_empty() {
+            return;
+        }
+
+        // Remove plots with matching log IDs from all plot types
+        let remove_matching_plots = |plot_data: &mut plot_util::PlotData| {
+            // Remove from plot values
+            plot_data
+                .plots_as_mut()
+                .retain(|plot| !log_ids_to_remove.contains(&plot.log_id()));
+
+            // Remove from plot labels
+            plot_data
+                .plot_labels_as_mut()
+                .retain(|label| !log_ids_to_remove.contains(&label.log_id()));
+        };
+
+        // Apply removal to all plot types
+        remove_matching_plots(plots.percentage_mut());
+        remove_matching_plots(plots.one_to_hundred_mut());
+        remove_matching_plots(plots.thousands_mut());
+
+        // Remove the settings marked for deletion
+        self.log_start_date_settings
+            .retain(|settings| !settings.marked_for_deletion());
+
+        // Invalidate plot cache since we modified the data
+        self.invalidate_plot = true;
     }
 
     /// Returns true if changes in plot settings occurred such that various cached values

--- a/src/plot/plot_settings.rs
+++ b/src/plot/plot_settings.rs
@@ -180,6 +180,7 @@ impl PlotSettings {
             self.remove_if_marked_for_deletion(plots);
             self.apply_deletions = false;
         }
+        self.set_highlighted(plots);
         self.update_plot_dates(plots);
         self.calc_plot_display_settings(plots);
         // If true then we set it to false such that it is only true for one frame
@@ -281,6 +282,27 @@ impl PlotSettings {
         for settings in &mut self.log_start_date_settings {
             date_settings::update_plot_dates(&mut self.invalidate_plot, plots, settings);
         }
+    }
+
+    fn set_highlighted(&self, plots: &mut Plots) {
+        let mut id_to_highlight = None;
+        for log_setting in &self.log_start_date_settings {
+            if log_setting.cursor_hovering_on() {
+                id_to_highlight = Some(log_setting.log_id());
+                break;
+            }
+        }
+        let set_plot_highlight = |plot_data: &mut plot_util::PlotData| {
+            for pd in plot_data.plots_as_mut() {
+                *pd.get_highlight_mut() = pd.log_id() == id_to_highlight.unwrap_or(usize::MAX);
+            }
+            for pl in plot_data.plot_labels_as_mut() {
+                *pl.get_highlight_mut() = pl.log_id() == id_to_highlight.unwrap_or(usize::MAX);
+            }
+        };
+        set_plot_highlight(plots.percentage_mut());
+        set_plot_highlight(plots.one_to_hundred_mut());
+        set_plot_highlight(plots.thousands_mut());
     }
 
     // Remove log settings and plots that match their ID if they are marked for deletion

--- a/src/plot/plot_settings/date_settings.rs
+++ b/src/plot/plot_settings/date_settings.rs
@@ -44,6 +44,7 @@ impl LoadedLogMetadata {
 
 #[derive(PartialEq, Eq, Deserialize, Serialize)]
 pub struct LoadedLogSettings {
+    //
     log_id: usize,
     log_descriptive_name: String,
     pub original_start_date: DateTime<Utc>,
@@ -56,6 +57,8 @@ pub struct LoadedLogSettings {
     show: bool,
     log_metadata: Option<Vec<LoadedLogMetadata>>,
     parse_info: Option<ParseInfo>,
+    marked_for_deletion: bool,
+    is_hovered: bool,
 }
 
 impl LoadedLogSettings {
@@ -84,6 +87,8 @@ impl LoadedLogSettings {
             show: true,
             log_metadata,
             parse_info,
+            marked_for_deletion: false,
+            is_hovered: false,
         }
     }
 
@@ -97,13 +102,14 @@ impl LoadedLogSettings {
 
     pub fn log_label(&self) -> String {
         format!(
-            "#{log_id} {descriptive_name} [{start_date}]",
+            "#{log_id} {descriptive_name}",
             log_id = self.log_id,
             descriptive_name = self.log_descriptive_name,
-            start_date = self.start_date.naive_utc()
+            //start_date = self.start_date.naive_utc()
         )
     }
 
+    /// This is the ID that connects settings to plots
     pub fn log_id(&self) -> usize {
         self.log_id
     }
@@ -122,6 +128,22 @@ impl LoadedLogSettings {
 
     pub fn parse_info(&self) -> Option<ParseInfo> {
         self.parse_info
+    }
+
+    pub fn marked_for_deletion(&self) -> bool {
+        self.marked_for_deletion
+    }
+
+    pub fn marked_for_deletion_mut(&mut self) -> &mut bool {
+        &mut self.marked_for_deletion
+    }
+
+    pub fn cursor_hovering_on(&self) -> bool {
+        self.is_hovered
+    }
+
+    pub fn cursor_hovering_on_mut(&mut self) -> &mut bool {
+        &mut self.is_hovered
     }
 }
 

--- a/src/plot/plot_settings/loaded_logs.rs
+++ b/src/plot/plot_settings/loaded_logs.rs
@@ -37,9 +37,9 @@ pub fn log_date_settings_ui(ui: &mut egui::Ui, loaded_log: &mut LoadedLogSetting
     ui.label(format!("{}", loaded_log.start_date().naive_utc()));
 
     let remove_button_text = if loaded_log.marked_for_deletion() {
-        RichText::new(format!("{}", egui_phosphor::regular::TRASH)).color(Color32::RED)
+        RichText::new(egui_phosphor::regular::TRASH).color(Color32::RED)
     } else {
-        RichText::new(format!("{}", egui_phosphor::regular::TRASH)).color(Color32::YELLOW)
+        RichText::new(egui_phosphor::regular::TRASH).color(Color32::YELLOW)
     };
     let button_resp = ui.button(remove_button_text);
     if button_resp.clicked() {

--- a/src/plot/plot_settings/loaded_logs.rs
+++ b/src/plot/plot_settings/loaded_logs.rs
@@ -9,36 +9,54 @@ use crate::{
 
 use super::date_settings::LoadedLogSettings;
 
-pub fn log_date_settings_ui(ui: &mut egui::Ui, settings: &mut LoadedLogSettings) {
-    let log_name_date = settings.log_label();
-    let check_box_text = RichText::new(if settings.show_log() {
+pub fn log_date_settings_ui(ui: &mut egui::Ui, loaded_log: &mut LoadedLogSettings) {
+    let log_name_date = loaded_log.log_label();
+    let check_box_text = RichText::new(if loaded_log.show_log() {
         regular::EYE
     } else {
         regular::EYE_SLASH
     });
-    ui.checkbox(settings.show_log_mut(), check_box_text);
+    ui.checkbox(loaded_log.show_log_mut(), check_box_text);
     let log_button_text = RichText::new(log_name_date.clone());
-    let log_button_text = if settings.show_log() {
+    let log_button_text = if loaded_log.show_log() {
         log_button_text.strong()
     } else {
         log_button_text
     };
     let button_resp = ui.button(log_button_text);
     if button_resp.clicked() {
-        settings.clicked = !settings.clicked;
+        loaded_log.clicked = !loaded_log.clicked;
     }
     if button_resp.hovered() {
         button_resp.on_hover_text("Click to modify log settings");
+        *loaded_log.cursor_hovering_on_mut() = true;
+    } else {
+        *loaded_log.cursor_hovering_on_mut() = false;
     }
 
-    if settings.tmp_date_buf.is_empty() {
-        settings.tmp_date_buf = settings
+    ui.label(format!("{}", loaded_log.start_date().naive_utc()));
+
+    let remove_button_text = if loaded_log.marked_for_deletion() {
+        RichText::new(format!("{}", egui_phosphor::regular::TRASH)).color(Color32::RED)
+    } else {
+        RichText::new(format!("{}", egui_phosphor::regular::TRASH)).color(Color32::YELLOW)
+    };
+    let button_resp = ui.button(remove_button_text);
+    if button_resp.clicked() {
+        *loaded_log.marked_for_deletion_mut() = !*loaded_log.marked_for_deletion_mut();
+    }
+    if button_resp.hovered() {
+        button_resp.on_hover_text("Remove from loaded files");
+    }
+
+    if loaded_log.tmp_date_buf.is_empty() {
+        loaded_log.tmp_date_buf = loaded_log
             .start_date()
             .format("%Y-%m-%d %H:%M:%S%.f")
             .to_string();
     }
-    if settings.clicked {
-        log_settings_window(ui, settings, &log_name_date);
+    if loaded_log.clicked {
+        log_settings_window(ui, loaded_log, &log_name_date);
     }
 }
 


### PR DESCRIPTION
#### PR Type

- [x] 💰 Feature
- [ ] 🪲 Bug Fix
- [ ] 👷‍♀️ Refactor
- [ ] 📖 Documentation Update

#### Description

<!--- Provide a summary of your changes -->
<!--- Link to any related issues this PR resolves -->
<!--- If integration tests have been performed, describe the tests along with their outcomes -->

- Allow deleting individual loaded files without removing everything at once.
- Hovering the cursor over a loaded log will highlight the plots and plot labels that came from that log.

#### Checklist

- [x] 🌞 Changelog updated
