### PR TITLE
update openssl to fix RUSTSEC-2025-0022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `reqwest`: 0.12.14 → 0.12.15 ([#218](https://github.com/luftkode/plotinator3000/pull/218))
 - `cargo-bins/cargo-binstall`: 1.12.1 → 1.12.2 ([#217](https://github.com/luftkode/plotinator3000/pull/217))
 - `crambl/dependabot-changelog-writer`: 1.0.2 → 1.0.3 ([#219](https://github.com/luftkode/plotinator3000/pull/219))
+- `openssl ` 0.10.70 -> 0.10.72
+- `openssl-sys` 0.9.105 -> 0.9.107
 
 ## [1.11.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,9 +3034,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -3066,9 +3066,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
#### PR Type

- [ ] 💰 Feature
- [ ] 🪲 Bug Fix
- [ ] 👷‍♀️ Refactor
- [ ] 📖 Documentation Update

#### Description

<!--- Provide a summary of your changes -->
<!--- Link to any related issues this PR resolves -->
<!--- If integration tests have been performed, describe the tests along with their outcomes -->

#### Checklist

- [x] 🌞 Changelog updated
