### PR TITLE
frame gps handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [1.29.1]
+
+- log warning instead of adding invalid gp time offset when `frame-gps`'s `gps_time` doesn't have a valid timestamp
+
 ## [1.29.0]
 
 - Update dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,7 +3498,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotinator-download"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-hdf5"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-log-if"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "chrono",
  "log",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-logs"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "byteorder",
  "chrono",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-macros"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "profiling",
  "puffin",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-mqtt"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-plot-util"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "chrono",
  "egui",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-proc-macros"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "quote",
  "syn",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-strfmt"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "chrono",
  "egui_plot",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-supported-formats"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "chrono",
  "log",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-test-util"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "paste",
  "testresult",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-ui-util"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "egui",
  "egui_plot",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator-updater"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "axoupdater",
  "eframe",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "plotinator3000"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["crates/*"]
 
 [workspace.package]
 authors = ["SkyTEM Surveys", "Marc Beck König"]
-version = "1.29.0"
+version = "1.29.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/plotinator-hdf5/src/frame_gps.rs
+++ b/crates/plotinator-hdf5/src/frame_gps.rs
@@ -248,18 +248,20 @@ impl FrameGpsDatasets {
                 lon.push([ts, entry.position[1]]);
                 alt.push([ts, entry.position[2]]);
             } else {
-                lat.push([ts, 1337.0]);
-                lon.push([ts, 1337.0]);
-                alt.push([ts, 1337.0]);
+                log::error!(
+                    "Expected entry position of length 3 or greater, got: {}",
+                    entry.position
+                );
             }
 
-            let offset = if let Ok(gps_dt) = DateTime::parse_from_rfc3339(entry.gps_time.as_str()) {
+            let gps_time = entry.gps_time.as_str();
+            if let Ok(gps_dt) = DateTime::parse_from_rfc3339(gps_time) {
                 let sys_dt = Utc.timestamp_nanos(*entry.timestamp);
-                sys_dt.signed_duration_since(gps_dt).num_milliseconds() as f64
+                let offset = sys_dt.signed_duration_since(gps_dt).num_milliseconds() as f64;
+                gps_time_offset.push([ts, offset]);
             } else {
-                1337.0
+                log::warn!("Invalid GPS time offset: {gps_time}");
             };
-            gps_time_offset.push([ts, offset]);
         }
         Ok(vec![
             RawPlot::new(

--- a/crates/plotinator-hdf5/src/frame_gps.rs
+++ b/crates/plotinator-hdf5/src/frame_gps.rs
@@ -219,6 +219,7 @@ impl FrameGpsDatasets {
         Ok(metadata)
     }
 
+    #[allow(clippy::too_many_lines, reason = "long but simple")]
     fn gps_data_to_rawplots(&self, id: u8) -> io::Result<Vec<RawPlot>> {
         let gps_data = self.gps_data(id)?;
         let data_len = self.len(id)?;

--- a/crates/plotinator-hdf5/src/util.rs
+++ b/crates/plotinator-hdf5/src/util.rs
@@ -37,7 +37,7 @@ pub(crate) fn log_all_attributes(ds: &hdf5::Dataset) {
             log::error!("Failed reading attribute '{attr:?}' value as string");
             continue;
         };
-        log::info!("Attr: {attr_val_as_str}");
+        log::debug!("Attr: {attr_val_as_str}");
     }
 }
 


### PR DESCRIPTION
- **log warning instead of adding invalid gp time offset when frame-gps's gps_time doesn't have a valid timestamp**
- **log HDF5 attributes as debug instead of info**
